### PR TITLE
Send access_token in HTTP Authorization header

### DIFF
--- a/lib/firebase.rb
+++ b/lib/firebase.rb
@@ -11,17 +11,15 @@ module Firebase
   class Client
     attr_accessor :access_token, :request
 
-    def initialize(base_uri, access_token)
+    def initialize(base_uri, access_token = nil)
       if base_uri !~ URI::regexp(%w(https))
         raise ArgumentError.new('base_uri must be a valid https uri')
       end
       base_uri += '/' unless base_uri.end_with?('/')
-      @request = HTTPClient.new({
-        :base_url => base_uri,
-        :default_header => {
-          'Content-Type' => 'application/json'
-        }
-      })
+      headers = { 'Content-Type' => 'application/json' }.merge(
+        access_token ? { 'Authorization' => "Bearer #{access_token}" } : {}
+      )
+      @request = HTTPClient.new(base_url: base_uri, default_header: headers)
       @access_token = access_token
     end
 
@@ -66,7 +64,7 @@ module Firebase
     def process(verb, path, data=nil, query={})
       Firebase::Response.new @request.request(verb, "#{path}.json", {
         :body             => (data && data.to_json),
-        :query            => { :access_token => @access_token }.merge(query),
+        :query            => query,
         :follow_redirect  => true
       })
     end

--- a/spec/firebase_spec.rb
+++ b/spec/firebase_spec.rb
@@ -119,14 +119,23 @@ describe "Firebase" do
   end
 
   describe "http processing" do
-    it "sends custom auth" do
+    it "does not send token in query params" do
       firebase = Firebase::Client.new('https://test.firebaseio.com', 'secret')
       expect(firebase.request).to receive(:request).with(:get, "todos.json", {
         :body => nil,
-        :query => {:auth => "secret", :foo => 'bar'},
+        :query => {:foo => 'bar'},
         :follow_redirect => true
       })
       firebase.get('todos', :foo => 'bar')
+    end
+
+    it "sends token in Authorization header" do
+      firebase = Firebase::Client.new('https://test.firebaseio.com', 'secret')
+      allow(firebase.request).to receive(:request) do |params|
+        @headers = firebase.request.default_header
+      end
+      firebase.get('todos', :foo => 'bar')
+      expect(@headers['Authorization']).to eq 'Bearer secret'
     end
   end
 end


### PR DESCRIPTION
Per https://developers.google.com/identity/protocols/OAuth2ServiceAccount:

> After your application obtains an access token, you can use the token to make calls to a Google 
> API on behalf of a given user account or service account. To do this, include the access token
> in a request to the API by including either an access_token query parameter or an
> Authorization: Bearer HTTP header. When possible, the HTTP header is preferable, because
> query strings tend to be visible in server logs.

This PR applies the access_token to the request headers rather than the query string